### PR TITLE
[No review required] Make Diameter messages appear in call flow

### DIFF
--- a/clearwater_sas_resource_bundle.yaml
+++ b/clearwater_sas_resource_bundle.yaml
@@ -212,7 +212,7 @@ events:
 
       <sas:fixed-width-font>{{ var_data[2] | decompress | decode_diameter_details }}</sas:fixed-width-font>
     call_flow:
-      data: "{{ var_data[2] | decompress }}"
+      data: "{{ var_data[2] | decompress | binary }}"
       protocol: _Diameter  # The leading underscore means that this is a builtin protocol.
       direction: out
       remote_address: "{{var_data[0]}}:{{static_data[0]}}"
@@ -226,7 +226,7 @@ events:
 
       <sas:fixed-width-font>{{ var_data[2] | decompress | decode_diameter_details }}</sas:fixed-width-font>
     call_flow:
-      data: "{{ var_data[2] | decompress }}"
+      data: "{{ var_data[2] | decompress | binary }}"
       protocol: _Diameter  # The leading underscore means that this is a builtin protocol.
       direction: in
       remote_address: "{{var_data[0]}}:{{static_data[0]}}"


### PR DESCRIPTION
Diameter messages are binary so we have to pass through the `binary` filter before passing into the call flow.

@tcaterisano tested this by uploading this code change to his SAS and using view a call trace. The call flow tab correctly contained the Diameter flows. 