### PR TITLE
[No review required] Add a message: field to the call flow for diameter messages

### DIFF
--- a/clearwater_sas_resource_bundle.yaml
+++ b/clearwater_sas_resource_bundle.yaml
@@ -213,6 +213,7 @@ events:
       <sas:fixed-width-font>{{ var_data[2] | decompress | decode_diameter_details }}</sas:fixed-width-font>
     call_flow:
       data: "{{ var_data[2] | decompress | binary }}"
+      message: "{{ var_data[2] | decompress | decode_diameter_details }}"
       protocol: _Diameter  # The leading underscore means that this is a builtin protocol.
       direction: out
       remote_address: "{{var_data[0]}}:{{static_data[0]}}"
@@ -227,6 +228,7 @@ events:
       <sas:fixed-width-font>{{ var_data[2] | decompress | decode_diameter_details }}</sas:fixed-width-font>
     call_flow:
       data: "{{ var_data[2] | decompress | binary }}"
+      message: "{{ var_data[2] | decompress | decode_diameter_details }}"
       protocol: _Diameter  # The leading underscore means that this is a builtin protocol.
       direction: in
       remote_address: "{{var_data[0]}}:{{static_data[0]}}"


### PR DESCRIPTION
Needed to allow SAS to display the decoded body of Diameter messages in the call flow. 