### PR TITLE
Reviewer Graeme - Fix missing event level

### DIFF
--- a/clearwater_sas_resource_bundle.yaml
+++ b/clearwater_sas_resource_bundle.yaml
@@ -190,7 +190,7 @@ events:
     summary: "Memcached get request returned tombstone for {{ var_data[0] }}"
     details: |
       CAS of tombstone: {{ static_data[0] | uint32 }}
-    level:
+    level: 40
 
   0x000103:
     summary: "Memcached get request found no data for key {{ var_data[0] }}"


### PR DESCRIPTION
Tested on a live deployment.  Level 40 is the same level as the other similar events around this one.