### PR TITLE
[No review required] Fix some bugs in compression support

### DIFF
--- a/clearwater_sas_resource_bundle.yaml
+++ b/clearwater_sas_resource_bundle.yaml
@@ -40,11 +40,11 @@ events:
   # Common events and protocol flows (0x000000 - 0x7FFFFF).
   #
   0x000001:
-    summary: "SIP message received: {{ var_data[1] | decode_sip_summary }}"
+    summary: 'SIP message received: {{ var_data[1] | decompress: "sip" | decode_sip_summary }}'
     details: |
       SIP message received:
 
-      <sas:fixed-width-font>{{ var_data[1] | decode_sip_details }}</sas:fixed-width-font>
+      <sas:fixed-width-font>{{ var_data[1] | decompress: "sip" | decode_sip_details }}</sas:fixed-width-font>
     call_flow:
       data: '{{ var_data[1] | decompress: "sip" }}'
       protocol: _SIP  # The leading underscore means that this is a builtin protocol.
@@ -53,11 +53,11 @@ events:
     level:   60
 
   0x000002:
-    summary: "SIP message sent: {{ var_data[1] | decode_sip_summary }}"
+    summary: 'SIP message sent: {{ var_data[1] | decompress: "sip" | decode_sip_summary }}'
     details: |
       SIP message sent:
 
-      <sas:fixed-width-font>{{ var_data[1] | decode_sip_details }}</sas:fixed-width-font>
+      <sas:fixed-width-font>{{ var_data[1] | decompress: "sip" | decode_sip_details }}</sas:fixed-width-font>
     call_flow:
       data: '{{ var_data[1] | decompress: "sip" }}'
       protocol: _SIP  # The leading underscore means that this is a builtin protocol.

--- a/clearwater_sas_resource_bundle.yaml
+++ b/clearwater_sas_resource_bundle.yaml
@@ -250,7 +250,7 @@ events:
     level: 60
 
   0x000011:
-    summary: 'Timeout sending diameter {{ var_data[0] | decode_diameter_summary }}'
+    summary: 'Timeout sending diameter {{ var_data[0] | decompress | decode_diameter_summary }}'
     details: |
       Timeout sending diameter message:
 

--- a/clearwater_sas_resource_bundle.yaml
+++ b/clearwater_sas_resource_bundle.yaml
@@ -206,6 +206,17 @@ events:
   #
   # Diameter flows.
   #
+  # The call_flow sections of these events are a bit hacky and work around the
+  # fact that SAS does not handle compressed binary messages properly in the
+  # ladder diagram. To fix this we:
+  # -  Specify the protocol as `Diameter` rather than `_Diameter` which causes
+  #    SAS to treat it as a generic protocol.
+  # -  Specify the caption and message explicitly.
+  # -  Run the data through `hex_and_ascii` before passing to the call flow.
+  #    This causes it to become valid UTF-8. This is OK - we are specifying the
+  #    caption and message so the `data` field is only used for message
+  #    matching.
+  #
   0x00000F:
     summary: 'Sending diameter {{ var_data[2] | decompress | decode_diameter_summary }}'
     details: |
@@ -213,9 +224,10 @@ events:
 
       <sas:fixed-width-font>{{ var_data[2] | decompress | decode_diameter_details }}</sas:fixed-width-font>
     call_flow:
-      data: "{{ var_data[2] | decompress | binary }}"
+      data: "{{ var_data[2] | decompress | hex_and_ascii }}"
+      caption: "{{ var_data[2] | decompress | decode_diameter_summary }}"
       message: "{{ var_data[2] | decompress | decode_diameter_details }}"
-      protocol: _Diameter  # The leading underscore means that this is a builtin protocol.
+      protocol: Diameter
       direction: out
       remote_address: "{{var_data[0]}}:{{static_data[0]}}"
       local_address: "{{var_data[1]}}:{{static_data[1]}}"
@@ -228,9 +240,10 @@ events:
 
       <sas:fixed-width-font>{{ var_data[2] | decompress | decode_diameter_details }}</sas:fixed-width-font>
     call_flow:
-      data: "{{ var_data[2] | decompress | binary }}"
+      data: "{{ var_data[2] | decompress | hex_and_ascii }}"
+      caption: "{{ var_data[2] | decompress | decode_diameter_summary }}"
       message: "{{ var_data[2] | decompress | decode_diameter_details }}"
-      protocol: _Diameter  # The leading underscore means that this is a builtin protocol.
+      protocol: Diameter
       direction: in
       remote_address: "{{var_data[0]}}:{{static_data[0]}}"
       local_address: "{{var_data[1]}}:{{static_data[1]}}"

--- a/clearwater_sas_resource_bundle.yaml
+++ b/clearwater_sas_resource_bundle.yaml
@@ -33,7 +33,7 @@
 # as those licenses appear in the file LICENSE-OPENSSL.
 
 info:
-  identifier: "org.projectclearwater.20150507"
+  identifier: "org.projectclearwater.20150519"
 
 events:
   #


### PR DESCRIPTION
Fixes the following issues:

* Missing `decompress` calls for some events.
* Add a workaround for the fact that SAS doesn't handle compressed messages correctly in the ladder diagram. 