### PR TITLE
[Reviewer: Andy] Extra SAS logs for topology neutral memcached store

### DIFF
--- a/clearwater_sas_resource_bundle.yaml
+++ b/clearwater_sas_resource_bundle.yaml
@@ -378,7 +378,7 @@ events:
     level: 40
 
   0x00010D:
-    summary: "Attempt memcached operation to host {{ var_data[0] }}"
+    summary: "Attempt memcached operation to host {{ var_data[0] }} (port {{ static_data[0] }})"
     level: 20
 
   0x000200:

--- a/clearwater_sas_resource_bundle.yaml
+++ b/clearwater_sas_resource_bundle.yaml
@@ -371,9 +371,15 @@ events:
 
   0x00010C:
     summary: "Deleting memcached data for key {{ var_data[0] }} failed"
-    details: |
-      Deletion failed for key {{ var_data[0] }} on replica {{ static_data[0] }} (out of {{ static_data[1] }} replicas)
     level: 40
+
+  0x00010D:
+    summary: "Unable to perform memcached operation, {{ var_data[0] }} resolves to 0 hosts"
+    level: 40
+
+  0x00010D:
+    summary: "Attempt memcached operation to host {{ var_data[0] }}"
+    level: 20
 
   0x000200:
     summary: 'The SRV lookup has returned for target: {{ var_data[0] }}'


### PR DESCRIPTION
Andy, as part of adding DNS and connection pooling support to the topology neutral memcached store, I have added a some SAS log to cover what Astaire any given request has been sent to (this was agreed with support). This is the corresponding change to the resource bundle. 

As part of this I have also re-purposed an existing SAS log. 0x00010C was logged from the topology-aware store when a delete request failed to any replica. This was inconsistent with all the other logs in the store (which only logged overall operations, not the result of requests to single replicas) and I don't think it was actually a useful log in the first place. As such I have made it into a generic "delete failed" log, and used it from within the topology-neutral store. 