### PR TITLE
[Reviewer AMC] 'binary' flag required for events where call_flow data uses 'sip' compression

### DIFF
--- a/clearwater_sas_resource_bundle.yaml
+++ b/clearwater_sas_resource_bundle.yaml
@@ -46,7 +46,7 @@ events:
 
       <sas:fixed-width-font>{{ var_data[1] | decompress: "sip" | decode_sip_details }}</sas:fixed-width-font>
     call_flow:
-      data: '{{ var_data[1] | decompress: "sip" }}'
+      data: '{{ var_data[1] | decompress: "sip" | binary }}'
       protocol: _SIP  # The leading underscore means that this is a builtin protocol.
       direction: in
       remote_address: "{{var_data[0]}}:{{static_data[1]}}"
@@ -59,7 +59,7 @@ events:
 
       <sas:fixed-width-font>{{ var_data[1] | decompress: "sip" | decode_sip_details }}</sas:fixed-width-font>
     call_flow:
-      data: '{{ var_data[1] | decompress: "sip" }}'
+      data: '{{ var_data[1] | decompress: "sip" | binary }}'
       protocol: _SIP  # The leading underscore means that this is a builtin protocol.
       direction: out
       remote_address: "{{var_data[0]}}:{{static_data[1]}}"


### PR DESCRIPTION
If 'sip' compression is in use (as it is for events 0x000001 and 0x000002), SAS requires that the data is also marked "binary" so that SAS can decode the data for the purposes of building the ladder diagram.

Spotted when attempting to view the SAS trail for an SMS.  The change was made to the SAS bundle in use whereupon the ladder diagram displayed successfully.

Let me know if you want me to update SAS datestamps as part of this change.